### PR TITLE
use npm version of d3-chart-framework in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Hopefully, this answers the why to `d3-chart-framework` and you begin to use it 
 ## Hows does it work?
 The main idea behind `d3-chart-framework` is to create *detached* `Node` class(es), which are an SVG group that are not immediately attached to the DOM. The key word here is *detached*. This simple, yet effective method allows for custom, *reusable*, *extendable* `Node` classes that utilize the D3js [workflow](https://github.com/d3/d3-selection/blob/master/README.md#joining-data).
 
-A `Node` can be any visualization, for example, a single 'circle' SVG element or a more sophisticated group of SVG elements, such as a line segment that contains two circles for the start and end points, connected by a 'line', such as the `[SegmentNode](/examples/shared/nodes/SegmentNode.js)`. 
+A `Node` can be any visualization, for example, a single 'circle' SVG element or a more sophisticated group of SVG elements, such as a line segment that contains two circles for the start and end points, connected by a 'line', such as the `[SegmentNode](/examples/shared/nodes/SegmentNode.js)`.
 
 Therefore to utilize `d3-chart-framework`, one only has to create one or more custom nodes and provide them to a Chart or Plot.
 
@@ -65,12 +65,12 @@ The current external dependencies are:
 ## Integration Examples
 I have provided an example of using `d3-chart-framework` with meteor and react. This is a very powerful framework combination and is very easy to get working out-of-the-box. However, meteor does require MongoDB and this may or may not work for you. See [react-meteor](examples/react-meteor/README.md)
 
-As an alternative, you may use `webpack`, `browserify`, or even `<script>` tags combined with any server-side framework of your choosing, such as [django](https://www.djangoproject.com/), [ruby on rails](http://rubyonrails.org/), or [hapi](https://hapijs.com/). 
+As an alternative, you may use `webpack`, `browserify`, or even `<script>` tags combined with any server-side framework of your choosing, such as [django](https://www.djangoproject.com/), [ruby on rails](http://rubyonrails.org/), or [hapi](https://hapijs.com/).
 
 
 ## About
 I am a software engineer at EcoHealth Alliance, Inc [(EHA)](http://ecohealthalliance.org).
 
-EHA is a non-profit organization who leads cutting-edge research into the critical connections between human and wildlife health and delicate ecosystems. With this science we develop solutions that promote conservation and prevent pandemics. 
+EHA is a non-profit organization who leads cutting-edge research into the critical connections between human and wildlife health and delicate ecosystems. With this science we develop solutions that promote conservation and prevent pandemics.
 
-If you'd like to learn more, please check out some of our work at [http://apps.eha.io](https://apps.eha.io).
+If you'd like to learn more, please check out some of our work at [http://apps.eha.io](http://apps.eha.io).

--- a/examples/react-meteor/chart-framework-app/client/main.jsx
+++ b/examples/react-meteor/chart-framework-app/client/main.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Meteor } from 'meteor/meteor';
 import { render } from 'react-dom';
 
-import '../imports/lib/stylesheets/d3cf-main.css';
+import '../node_modules/d3-chart-framework/build/stylesheets/d3cf-main.css';
 
 import App from '../imports/ui/App.jsx';
 

--- a/examples/react-meteor/chart-framework-app/imports/lib/d3-chart-framework.js
+++ b/examples/react-meteor/chart-framework-app/imports/lib/d3-chart-framework.js
@@ -1,1 +1,0 @@
-../../../../../build/d3-chart-framework.js

--- a/examples/react-meteor/chart-framework-app/imports/lib/stylesheets
+++ b/examples/react-meteor/chart-framework-app/imports/lib/stylesheets
@@ -1,1 +1,0 @@
-../../../../../build/stylesheets/

--- a/examples/react-meteor/chart-framework-app/imports/ui/Plot.jsx
+++ b/examples/react-meteor/chart-framework-app/imports/ui/Plot.jsx
@@ -1,7 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import Immutable from 'immutable'
 /* immutable vs mutable data structures comes down to cold, hard math */
-import { ScatterPlot, InvalidNodeError } from '../lib/d3-chart-framework';
+import { ScatterPlot, InvalidNodeError } from 'd3-chart-framework';
 import RectNode from '../api/nodes/RectNode';
 
 import Toolbar from './Toolbar';

--- a/examples/react-meteor/chart-framework-app/package.json
+++ b/examples/react-meteor/chart-framework-app/package.json
@@ -14,6 +14,7 @@
     "react-addons-shallow-compare": "^15.4.1",
     "react-dom": "^15.4.1",
     "react-virtualized": "^8.8.1",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "d3-chart-framework": "^0.0.1"
   }
 }

--- a/examples/react-meteor/chart-framework-app/server/main.js
+++ b/examples/react-meteor/chart-framework-app/server/main.js
@@ -1,8 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { Incidents } from '../imports/api/incidents';
 
-import { Heapsort, HeapsortImmutable } from '../imports/lib/d3-chart-framework';
-
 function randomDate(start, end) {
     return new Date(start.getTime() + Math.random() * (end.getTime() - start.getTime()));
 }

--- a/examples/shared/nodes/RectNode.js
+++ b/examples/shared/nodes/RectNode.js
@@ -1,6 +1,6 @@
 const d3 = require('d3');
 
-import { Node } from '../../lib/d3-chart-framework';
+import { Node } from 'd3-chart-framework';
 
 
 const MINIMUM_MARKER_WIDTH = 10;

--- a/examples/shared/nodes/SegmentNode.js
+++ b/examples/shared/nodes/SegmentNode.js
@@ -1,6 +1,6 @@
 import d3 from 'd3';
 import _ from 'underscore';
-import { Node } from '../../lib/d3-chart-framework';
+import { Node } from 'd3-chart-framework';
 
 const MINIMUM_LINE_STROKE = 4;
 const MINIMUM_CIRCLE_RADIUS = 5;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d3-chart-framework",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Provides an extensible, reusable approach to building charts with D3js.org",
   "keywords": [
     "d3",
@@ -20,6 +20,7 @@
     "type": "git",
     "url": "https://github.com/dan-nyanko/d3-chart-framework.git"
   },
+  "main": "build/d3-chart-framework.js",
   "scripts": {
     "clean": "rm -rf build && mkdir build",
     "build": "./node_modules/.bin/webpack --mode=build",

--- a/src/index.js
+++ b/src/index.js
@@ -7,5 +7,3 @@ export { default as Plot } from './Plot';
 export { default as ScatterPlot } from './ScatterPlot';
 export { default as Tooltip } from './Tooltip';
 export { default as Zoom } from './Zoom';
-export { default as Heapsort } from './Heapsort';
-export { default as HeapsortImmutable } from './HeapsortImmutable';


### PR DESCRIPTION
- Fix missing "main" key in package.json
- Update examples to use npm version of d3-chart-framework
- Update README.md
- Remove reference to Heapsort, HeapsortImmutable from index.js
- bump to version 0.0.2